### PR TITLE
replace old patching method by more neat one

### DIFF
--- a/src/ceval.c
+++ b/src/ceval.c
@@ -796,7 +796,6 @@ PyEval_EvalFrame(PyFrameObject *f) {
 PyObject *
 hooked_PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
 {
-	__asm__("nop");
 #ifdef DXPAIRS
     int lastopcode = 0;
 #endif


### PR DESCRIPTION
Hi, thanks for this package! Current patching approach uses `rax` register to store `hooked_PyEval_EvalFrameEx` address. In order to preserve state, `rax` is pushed right before loading it with `hooked_PyEval_EvalFrameEx ` address. Additionally `nop` is placed inside `hooked_PyEval_EvalFrameEx` acting as a placeholder for popping `rax`. All instructions from the beginning of  `hooked_PyEval_EvalFrameEx` up to the address of `nop` are shifted by 1 down to insert `pop rax` as the very first instruction to restore state right after the jump. Instead of that we can skip using registers at all by manipulating stack. Steps  are:
1. Push low 32 bits of `hooked_PyEval_EvalFrameEx`. Since pushed value is 64 bits, only first 32 bits are correct. Remaining are garbage so far.
2. Move high 32 bits as 4byte value into address (stack pointer + 4). This inserts missing high 32 bits of `hooked_PyEval_EvalFrameEx` address (previously garbage).
3. Perform return from procedure. `hooked_PyEval_EvalFrameEx` 64bit address on top of the stack is popped by cpu and then it jumps to that address.

As a result: no state saving/restoration is needed and `nop` approach can be dropped.
This is done in such way because you cannot jump to absolute 64bit immediate address on x86_64 and you cannot push 64bit immediate value either.
You can also push 4 words (16bits) that represents function address and preform return. You cannot push 2x32 however. Matter of preference whether you do it like that or as I did but my way uses less memory.